### PR TITLE
Make npm-run-all work on node 0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: false
 language: node_js
 node_js:
+  - "0.10"
   - "0.12"
   - "iojs"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
   - "0.10"
   - "0.12"
   - "iojs"
+before_install:
+  - npm install -g npm@latest

--- a/README.md
+++ b/README.md
@@ -3,8 +3,17 @@
 [![Build Status](https://travis-ci.org/mysticatea/npm-run-all.svg?branch=master)](https://travis-ci.org/mysticatea/npm-run-all)
 [![npm version](https://badge.fury.io/js/npm-run-all.svg)](http://badge.fury.io/js/npm-run-all)
 
-A CLI tool to run multiple npm-scripts on sequential or parallel.
+A CLI tool to run multiple npm-scripts sequentially or in parallel.
 
+## Platform dependencies
+
+This package works in both Windows and UNIX-like environments.
+
+It requires at least node version 0.10 and **npm version 2.0.0**. To upgrade npm, run:
+
+```
+npm install -g npm@latest
+```
 
 ## Installation
 
@@ -27,7 +36,7 @@ Usage: npm-run-all [OPTIONS] [...tasks]
     -v, --version               Print version number.
 ```
 
-### Run tasks on sequential
+### Run tasks sequentially
 
 ```
 npm-run-all build:html build:js
@@ -35,7 +44,7 @@ npm-run-all build:html build:js
 
 This is same as `npm run build:html && npm run build:js`.
 
-### Run tasks on parallel
+### Run tasks in parallel
 
 ```
 npm-run-all --parallel watch:html watch:js
@@ -45,23 +54,23 @@ This is same as `npm run watch:html & npm run watch:js`.
 
 Of course, this can be run on **Windows** as well!
 
-### Run tasks on mixed sequential and parallel.
+### Run a mix of sequential and parallel tasks.
 
 ```
 npm-run-all clean lint --parallel watch:html watch:js
 ```
 
 1. First, this runs `clean` and `lint` sequentially.
-2. Next, runs `watch:html` and `watch:js` parallelly.
+2. Next, runs `watch:html` and `watch:js` in parallell.
 
 ```
 npm-run-all a b --parallel c d --sequential e f --parallel g h i
 ```
 
 1. First, runs `a` and `b` sequentially.
-2. Second, runs `c` and `d` parallelly.
+2. Second, runs `c` and `d` in parallell.
 3. Third, runs `e` and `f` sequentially.
-4. Lastly, runs `g`, `h`, and `i` parallelly.
+4. Lastly, runs `g`, `h`, and `i` in parallell.
 
 
 ## Node API
@@ -80,7 +89,7 @@ Run npm-scripts.
 
 * **tasks** `string|string[]` -- Task names.
 * **options** `object`
-  * **options.parallel** `boolean` -- A flag to run tasks on parallel. By default,
+  * **options.parallel** `boolean` -- A flag to run tasks in parallel. By default,
     `false`.
   * **options.stdin** `stream.Readable` -- A readable stream that sends to stdin
     of tasks. By default, nothing. Set `process.stdin` in order to send from
@@ -92,5 +101,5 @@ Run npm-scripts.
     of tasks. By default, nothing. Set `process.stderr` in order to print to
     console.
 
-`runAll` returns a promise that becomes *fulfilled* when done all tasks.
-The promise will become *rejected* when any of tasks exited with non-zero code.
+`runAll` returns a promise that becomes *fulfilled* when all tasks are completed.
+The promise will become *rejected* when any of the tasks exit with a non-zero code.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "npm-run-all": "^1.1.2",
     "power-assert": "^0.10.2",
     "rimraf": "^2.3.2",
-    "runsync": "^0.1.8",
     "shelljs": "^0.4.0"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "eslint": "^0.18.0",
     "espower-babel": "^2.0.0",
     "mocha": "^2.2.4",
-    "npm-run-all": "^1.1.2",
     "power-assert": "^0.10.2",
     "rimraf": "^2.3.2",
     "shelljs": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "test-task:error": "node test/tasks/error.js",
     "test-task:stdio": "node test/tasks/stdio.js"
   },
+  "dependencies": {
+    "es6-promise": "^2.0.1"
+  },
   "devDependencies": {
     "babel": "^5.0.12",
     "eslint": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
   "scripts": {
     "clean": "rimraf lib",
     "lint": "eslint src",
-    "build": "npm-run-all clean lint build:babel",
+    "build": "npm run clean && npm run lint && npm run build:babel",
     "build:babel": "babel src --out-dir lib",
-    "test": "npm-run-all build test:mocha",
+    "test": "npm run build && npm run test:mocha",
     "test:mocha": "mocha test/*.js --compilers js:espower-babel/guess --timeout 30000 --colors",
-    "testing": "npm-run-all clean --parallel testing:build testing:mocha",
+    "testing": "npm run clean && npm run testing:build && npm run testing:mocha",
     "testing:build": "npm run build:babel -- --watch --source-maps-inline",
     "testing:mocha": "npm run test:mocha -- --watch --growl",
     "test-task:env-check": "node test/tasks/env-check.js",
@@ -37,7 +37,9 @@
     "mocha": "^2.2.4",
     "npm-run-all": "^1.1.2",
     "power-assert": "^0.10.2",
-    "rimraf": "^2.3.2"
+    "rimraf": "^2.3.2",
+    "runsync": "^0.1.8",
+    "shelljs": "^0.4.0"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,7 @@
 import {spawn} from "child_process";
+import {polyfill} from "es6-promise";
+
+polyfill();
 
 function toArray(x) {
   if (x == null) {

--- a/test/common.js
+++ b/test/common.js
@@ -1,4 +1,4 @@
-import {execSync} from "child_process";
+import {exec} from "shelljs";
 import {PassThrough} from "stream";
 import assert from "power-assert";
 import {result, removeResult} from "./lib/util";
@@ -20,7 +20,7 @@ describe("npm-run-all", () => {
     });
 
     it("command version", () => {
-      execSync("node lib/command.js test-task:env-check");
+      exec("node lib/command.js test-task:env-check");
       assert(result() === "OK");
     });
   });
@@ -39,7 +39,8 @@ describe("npm-run-all", () => {
     });
 
     it("command version", () => {
-      assert.throws(() => execSync("node lib/command.js test-task:error"));
+      var res = exec("node lib/command.js test-task:error");
+      assert.ok(res.code > 0);
     });
   });
 

--- a/test/mixed.js
+++ b/test/mixed.js
@@ -1,4 +1,4 @@
-import {execSync} from "child_process";
+import {exec} from "shelljs";
 import assert from "power-assert";
 import {result, removeResult} from "./lib/util";
 
@@ -11,7 +11,7 @@ describe("npm-run-all", () => {
   after(removeResult);
 
   it("should run tasks, mixed sequential and parallel 1:", () => {
-    execSync("node lib/command.js \"test-task:append a\" -p \"test-task:append b\" \"test-task:append c\" -s \"test-task:append d\" \"test-task:append e\"");
+    exec("node lib/command.js \"test-task:append a\" -p \"test-task:append b\" \"test-task:append c\" -s \"test-task:append d\" \"test-task:append e\"");
     assert(result() === "aabcbcddee" ||
            result() === "aabccbddee" ||
            result() === "aacbbcddee" ||
@@ -19,7 +19,7 @@ describe("npm-run-all", () => {
   });
 
   it("should run tasks, mixed sequential and parallel 2:", () => {
-    execSync("node lib/command.js -p \"test-task:append b\" \"test-task:append c\" -s \"test-task:append d\" \"test-task:append e\"");
+    exec("node lib/command.js -p \"test-task:append b\" \"test-task:append c\" -s \"test-task:append d\" \"test-task:append e\"");
     assert(result() === "bcbcddee" ||
            result() === "bccbddee" ||
            result() === "cbbcddee" ||

--- a/test/parallel.js
+++ b/test/parallel.js
@@ -1,4 +1,4 @@
-import {execSync} from "child_process";
+import {exec} from "shelljs";
 import assert from "power-assert";
 import {result, removeResult} from "./lib/util";
 
@@ -22,7 +22,7 @@ describe("npm-run-all", () => {
     });
 
     it("command version", () => {
-      execSync("node lib/command.js --parallel \"test-task:append a\" \"test-task:append b\"");
+      exec("node lib/command.js --parallel \"test-task:append a\" \"test-task:append b\"");
       assert(result() === "abab" ||
              result() === "baba" ||
              result() === "abba" ||

--- a/test/sequential.js
+++ b/test/sequential.js
@@ -1,4 +1,4 @@
-import {execSync} from "child_process";
+import {exec} from "shelljs";
 import assert from "power-assert";
 import {result, removeResult} from "./lib/util";
 
@@ -19,7 +19,7 @@ describe("npm-run-all", () => {
     });
 
     it("command version", () => {
-      execSync("node lib/command.js \"test-task:append a\" \"test-task:append b\"");
+      exec("node lib/command.js \"test-task:append a\" \"test-task:append b\"");
       assert(result() === "aabb");
     });
   });


### PR DESCRIPTION
Ok, this should be good to go. Here are the changes:

* pretty much the only thing that needed to be changed in the core lib was to polyfill `Promise`
* I had to polyfill `execSync` in your tests, since that method is only available in 0.12
* I added node 0.10 to the Travis build matrix
* there would be additional changes to make it compatible with npm v1.x, but I did not address those since they were more widespread. Instead, I added a note to the README and set travis to install the latest version of npm 

I also needed to replace uses of `npm-run-all` in the package.json scripts so earlier bugs would not affect the build. Let me know if you are OK with this approach.

Thanks!