### PR TITLE
Fix: Windows - wrap npm path in quotes, use shell when spawning npm

### DIFF
--- a/src/lib/run-task.js
+++ b/src/lib/run-task.js
@@ -56,12 +56,17 @@ export default function runTask(task, stdin, stdout, stderr, prefixOptions) {
         const stdinKind = detectStreamKind(stdin, process.stdin);
         const stdoutKind = detectStreamKind(stdout, process.stdout);
         const stderrKind = detectStreamKind(stderr, process.stderr);
+        const options = {stdio: [stdinKind, stdoutKind, stderrKind]};
+
+        if (process.platform === "win32") {
+            options.shell = true;
+        }
 
         // Execute.
         cp = spawn(
             npmPath,
             ["run-script"].concat(prefixOptions, parseArgs(task)),
-            {stdio: [stdinKind, stdoutKind, stderrKind]}
+            options
         );
 
         // Piping stdio.

--- a/src/lib/which-npm.js
+++ b/src/lib/which-npm.js
@@ -23,7 +23,7 @@ export default function whichNpm() {
                     reject(err);
                 }
                 else {
-                    resolve(npmPath);
+                    resolve(process.platform === "win32" ? `"${npmPath}"` : npmPath);
                 }
             });
         });


### PR DESCRIPTION
Fixes #26