### PR TITLE
Fix to not leave any garbage.

### DIFF
--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -44,7 +44,7 @@ function toArray(x) {
  * @returns {string[]} replaced
  */
 function applyArguments(patterns, args) {
-    return patterns.map(pattern => pattern.replace(ARGS_PATTERN, (match, index) => {
+    return patterns.map(pattern => pattern.replace(ARGS_PATTERN, (unused, index) => {
         if (index === "@") {
             return shellQuote.quote(args);
         }
@@ -57,7 +57,7 @@ function applyArguments(patterns, args) {
             return shellQuote.quote([args[position - 1]]);
         }
 
-        return match;
+        return "";
     }));
 }
 
@@ -72,9 +72,9 @@ function applyArguments(patterns, args) {
  */
 function parsePatterns(patternOrPatterns, args) {
     const patterns = toArray(patternOrPatterns);
-    const hasArguments = Array.isArray(args) && args.length > 0;
+    const hasPlaceholder = patterns.filter(pattern => ARGS_PATTERN.test(pattern)).length > 0;
 
-    return hasArguments ? applyArguments(patterns, args) : patterns;
+    return hasPlaceholder ? applyArguments(patterns, args) : patterns;
 }
 
 /**

--- a/test/argument-placeholders.js
+++ b/test/argument-placeholders.js
@@ -28,40 +28,40 @@ describe("[argument-placeholders]", () => {
 
     beforeEach(removeResult);
 
-    describe("If arguments preceded by '--' are nothing, '{1}' should be as is:", () => {
+    describe("If arguments preceded by '--' are nothing, '{1}' should be empty:", () => {
         it("Node API", () =>
             nodeApi("test-task:dump {1}")
-                .then(() => assert(result() === "[\"{1}\"]"))
+                .then(() => assert(result() === "[]"))
         );
 
         it("npm-run-all command", () =>
             runAll(["test-task:dump {1}"])
-                .then(() => assert(result() === "[\"{1}\"]"))
+                .then(() => assert(result() === "[]"))
         );
 
         it("npm-run-all command (only '--' exists)", () =>
             runAll(["test-task:dump {1}", "--"])
-                .then(() => assert(result() === "[\"{1}\"]"))
+                .then(() => assert(result() === "[]"))
         );
 
         it("run-s command", () =>
             runSeq(["test-task:dump {1}"])
-                .then(() => assert(result() === "[\"{1}\"]"))
+                .then(() => assert(result() === "[]"))
         );
 
         it("run-s command (only '--' exists)", () =>
             runSeq(["test-task:dump {1}", "--"])
-                .then(() => assert(result() === "[\"{1}\"]"))
+                .then(() => assert(result() === "[]"))
         );
 
         it("run-p command", () =>
             runPar(["test-task:dump {1}"])
-                .then(() => assert(result() === "[\"{1}\"]"))
+                .then(() => assert(result() === "[]"))
         );
 
         it("run-p command (only '--' exists)", () =>
             runPar(["test-task:dump {1}", "--"])
-                .then(() => assert(result() === "[\"{1}\"]"))
+                .then(() => assert(result() === "[]"))
         );
     });
 
@@ -156,22 +156,22 @@ describe("[argument-placeholders]", () => {
     describe("Every '{1}', '{2}', '{@}' and '{*}' should be replaced by the arguments preceded by '--':", () => {
         it("Node API", () =>
             nodeApi("test-task:dump {1} {2} {3} {@} {*}", {arguments: ["1st", "2nd"]})
-                .then(() => assert(result() === "[\"1st\",\"2nd\",\"{3}\",\"1st\",\"2nd\",\"1st 2nd\"]"))
+                .then(() => assert(result() === "[\"1st\",\"2nd\",\"1st\",\"2nd\",\"1st 2nd\"]"))
         );
 
         it("npm-run-all command", () =>
             runAll(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\",\"{3}\",\"1st\",\"2nd\",\"1st 2nd\"]"))
+                .then(() => assert(result() === "[\"1st\",\"2nd\",\"1st\",\"2nd\",\"1st 2nd\"]"))
         );
 
         it("run-s command", () =>
             runSeq(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\",\"{3}\",\"1st\",\"2nd\",\"1st 2nd\"]"))
+                .then(() => assert(result() === "[\"1st\",\"2nd\",\"1st\",\"2nd\",\"1st 2nd\"]"))
         );
 
         it("run-p command", () =>
             runPar(["test-task:dump {1} {2} {3} {@} {*}", "--", "1st", "2nd"])
-                .then(() => assert(result() === "[\"1st\",\"2nd\",\"{3}\",\"1st\",\"2nd\",\"1st 2nd\"]"))
+                .then(() => assert(result() === "[\"1st\",\"2nd\",\"1st\",\"2nd\",\"1st 2nd\"]"))
         );
     });
 });


### PR DESCRIPTION
This realize optional arguments.

```
{
    "echo": "echo args are",
    "foo": "run-s \"echo -- {1}\" --"
}
```

The current specification and implementation are strange.
Since users can not be avoided, it is no exaggeration to say that bug.

```
$ npm run foo
> run-s "echo -- {1}" --
> echo args are "{1}"

args are "{1}"

```

On the other hand, this p-r's result is

```
$ npm run foo
> run-s "echo -- {1}" --
> echo args are

args are
```

Again, the user still have a way to pass-through `{1}` as is.