### PR TITLE
shorter shorthand via nra

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "bin": {
     "run-p": "bin/run-p/index.js",
     "run-s": "bin/run-s/index.js",
-    "npm-run-all": "bin/npm-run-all/index.js"
+    "npm-run-all": "bin/npm-run-all/index.js",
+    "nra": "bin/npm-run-all/index.js"
   },
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
`run-p` and `run-s` are short hand for `npm-run-all [-p|-s]`. Why not offer a shorthand for `npm-run-all` such as `nra` instead? `nra -p` and `nra -s` are just as short as `run-p` and `run-s` but less confusing then consistent usage of `nra` and `npm-run-all`. 
