### PR TITLE
fix: use run command instead of run-script

### DIFF
--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -165,7 +165,7 @@ We can use placeholders to give the arguments preceded by `--` to scripts.
 > npm-run-all build "start-server -- --port {1}" -- 8080
 ```
 
-This is useful to pass through arguments from `npm run-script` command.
+This is useful to pass through arguments from `npm run` command.
 
 ```json
 {

--- a/docs/run-p.md
+++ b/docs/run-p.md
@@ -125,7 +125,7 @@ We can use placeholders to give the arguments preceded by `--` to scripts.
 > run-p "start-server -- --port {1}" -- 8080
 ```
 
-This is useful to pass through arguments from `npm run-script` command.
+This is useful to pass through arguments from `npm run` command.
 
 ```json
 {

--- a/docs/run-s.md
+++ b/docs/run-s.md
@@ -120,7 +120,7 @@ We can use placeholders to give the arguments preceded by `--` to scripts.
 > run-s build "start-server -- --port {1}" -- 8080
 ```
 
-This is useful to pass through arguments from `npm run-script` command.
+This is useful to pass through arguments from `npm run` command.
 
 ```json
 {

--- a/src/lib/run-task.js
+++ b/src/lib/run-task.js
@@ -124,7 +124,7 @@ module.exports = function runTask(
         // Execute.
         cp = spawn(
             "npm",
-            ["run-script"].concat(prefixOptions, parseArgs(task)),
+            ["run"].concat(prefixOptions, parseArgs(task)),
             {stdio: [stdinKind, stdoutKind, stderrKind]}
         )
 


### PR DESCRIPTION
This uses `npm run` instead of `npm run-script` and makes it compatible with https://github.com/yarnpkg/yarn