### PR TITLE
Change labels to be displayed in individual colors for each task

### DIFF
--- a/src/lib/run-task.js
+++ b/src/lib/run-task.js
@@ -22,6 +22,25 @@ const spawn = require("./spawn")
 // Helpers
 //------------------------------------------------------------------------------
 
+const colors = [chalk.cyan, chalk.green, chalk.magenta, chalk.yellow, chalk.red]
+
+/**
+ * Select a color from given task name.
+ *
+ * @param {string} taskName - The task name.
+ * @returns {function} A colorize function that provided by `chalk`
+ */
+function selectColor(taskName) {
+    let hash = 0
+
+    for (const i in taskName) {
+        hash = ((hash << 5) - hash) + taskName.charCodeAt(i)
+        hash |= 0
+    }
+
+    return colors[Math.abs(hash) % colors.length]
+}
+
 /**
  * Wraps stdout/stderr with a transform stream to add the task name as prefix.
  *
@@ -36,7 +55,7 @@ function wrapLabeling(taskName, source, labelState) {
     }
 
     const label = padEnd(taskName, labelState.width)
-    const color = source.isTTY ? chalk.gray : (x) => x
+    const color = source.isTTY ? selectColor(taskName) : (x) => x
     const prefix = color(`[${label}] `)
     const stream = createPrefixTransform(prefix, labelState)
 


### PR DESCRIPTION
Hello, I changed labels to be displayed in individual colors for each task like a following screenshot. Please review. (Inspired by tj's debug module.)

<img width="850" alt="screen shot 2016-12-20 at 10 49 51 pm" src="https://cloud.githubusercontent.com/assets/291185/21352882/e92de8fe-c706-11e6-973c-7d8dc950deee.png">
