### PR TITLE
Chore: allow use of any built-in npm task

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chalk": "^1.1.3",
     "cross-spawn": "^4.0.0",
     "minimatch": "^3.0.2",
+    "npm": "^4.0.5",
     "object-assign": "^4.0.1",
     "pinkie-promise": "^2.0.1",
     "ps-tree": "^1.0.1",

--- a/src/lib/match-tasks.js
+++ b/src/lib/match-tasks.js
@@ -112,7 +112,7 @@ module.exports = function matchTasks(taskList, patterns) {
         })
 
         // Built-in tasks should be allowed.
-        if (!found && fullList.indexOf(filter.task) > -1) {
+        if (!found && (fullList.indexOf(filter.task) > -1 || filter.task === "env")) {
             taskSet.add(filter.task + filter.args, filter.task)
             found = true
         }

--- a/src/lib/match-tasks.js
+++ b/src/lib/match-tasks.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 const {Minimatch} = require("minimatch")
+const {fullList} = require("npm")
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -111,7 +112,7 @@ module.exports = function matchTasks(taskList, patterns) {
         })
 
         // Built-in tasks should be allowed.
-        if (!found && (filter.task === "restart" || filter.task === "env")) {
+        if (!found && fullList.indexOf(filter.task) > -1) {
             taskSet.add(filter.task + filter.args, filter.task)
             found = true
         }

--- a/src/lib/run-task.js
+++ b/src/lib/run-task.js
@@ -17,6 +17,7 @@ const padEnd = require("string.prototype.padend")
 const createHeader = require("./create-header")
 const createPrefixTransform = require("./create-prefix-transform-stream")
 const spawn = require("./spawn")
+const {fullList} = require("npm")
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -121,10 +122,13 @@ module.exports = function runTask(
             stdout.write(createHeader(task, packageInfo, sourceStdout.isTTY))
         }
 
+        const parsedTask = parseArgs(task)
+        const run = fullList.indexOf(parsedTask[0]) > -1 ? [] : ["run"]
+
         // Execute.
         cp = spawn(
             "npm",
-            ["run"].concat(prefixOptions, parseArgs(task)),
+            run.concat(prefixOptions, parsedTask),
             {stdio: [stdinKind, stdoutKind, stderrKind]}
         )
 

--- a/test/common.js
+++ b/test/common.js
@@ -228,6 +228,13 @@ describe("[common]", () => {
         it("run-p command", () => runPar(["env"]))
     })
 
+    describe("should be able to use any built-in task that can't be run with 'run' prefix:", () => {
+        it("Node API", () => nodeApi("help"))
+        it("npm-run-all command", () => runAll(["help"]))
+        it("run-s command", () => runSeq(["help"]))
+        it("run-p command", () => runPar(["help"]))
+    })
+
     if (process.platform === "win32") {
         describe("issue14", () => {
             it("Node API", () => nodeApi("test-task:issue14:win32"))


### PR DESCRIPTION
This allow the use of any built-in npm task and not just `restart` and `env`. There is actually use case where the user wants to use `publish` for example.

There is a weird exception for the `env` task as it is not part of the list of available npm commands but you can still run it as `npm run env` even if it's not part of your package.json scripts. 