### PR TITLE
Fix Case Sensitive NPM_EXECPATH

### DIFF
--- a/bin/npm-run-all/help.js
+++ b/bin/npm-run-all/help.js
@@ -34,7 +34,7 @@ Options:
     --max-parallel <number>  - Set the maximum number of parallelism. Default is
                                unlimited.
     --npm-path <string>  - - - Set the path to npm. Default is the value of
-                               environment variable NPM_EXECPATH.
+                               environment variable npm_execpath.
                                If the variable is not defined, then it's "npm".
                                In this case, the "npm" command must be found in
                                environment variable PATH.

--- a/bin/run-p/help.js
+++ b/bin/run-p/help.js
@@ -34,7 +34,7 @@ Options:
     --max-parallel <number>  - Set the maximum number of parallelism. Default is
                                unlimited.
     --npm-path <string>  - - - Set the path to npm. Default is the value of
-                               environment variable NPM_EXECPATH.
+                               environment variable npm_execpath.
                                If the variable is not defined, then it's "npm."
                                In this case, the "npm" command must be found in
                                environment variable PATH.

--- a/bin/run-s/help.js
+++ b/bin/run-s/help.js
@@ -32,7 +32,7 @@ Options:
                                itself will exit with non-zero code if one or
                                more tasks threw error(s).
     --npm-path <string>  - - - Set the path to npm. Default is the value of
-                               environment variable NPM_EXECPATH.
+                               environment variable npm_execpath.
                                If the variable is not defined, then it's "npm."
                                In this case, the "npm" command must be found in
                                environment variable PATH.

--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -50,7 +50,7 @@ Run npm-scripts.
     Default is `Number.POSITIVE_INFINITY`.
   - **options.npmPath** `string` --
     The path to npm.
-    Default is `process.env.NPM_EXECPATH` or `"npm"`.
+    Default is `process.env.npm_execpath` or `"npm"`.
   - **options.packageConfig** `object|null` --
     The map-like object to overwrite package configs.
     Keys are package names.

--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -39,7 +39,7 @@ Options:
     --max-parallel <number>  - Set the maximum number of parallelism. Default is
                                unlimited.
     --npm-path <string>  - - - Set the path to npm. Default is the value of
-                               environment variable NPM_EXECPATH.
+                               environment variable npm_execpath.
                                If the variable is not defined, then it's "npm."
                                In this case, the "npm" command must be found in
                                environment variable PATH.

--- a/docs/run-p.md
+++ b/docs/run-p.md
@@ -38,7 +38,7 @@ Options:
     --max-parallel <number>  - Set the maximum number of parallelism. Default is
                                unlimited.
     --npm-path <string>  - - - Set the path to npm. Default is the value of
-                               environment variable NPM_EXECPATH.
+                               environment variable npm_execpath.
                                If the variable is not defined, then it's "npm."
                                In this case, the "npm" command must be found in
                                environment variable PATH.

--- a/docs/run-s.md
+++ b/docs/run-s.md
@@ -36,7 +36,7 @@ Options:
                                itself will exit with non-zero code if one or
                                more tasks threw error(s).
     --npm-path <string>  - - - Set the path to npm. Default is the value of
-                               environment variable NPM_EXECPATH.
+                               environment variable npm_execpath.
                                If the variable is not defined, then it's "npm."
                                In this case, the "npm" command must be found in
                                environment variable PATH.

--- a/lib/index.js
+++ b/lib/index.js
@@ -204,7 +204,7 @@ function maxLength(length, name) {
  *   Default is unlimited.
  * @param {string} options.npmPath -
  *   The path to npm.
- *   Default is `process.env.NPM_EXECPATH`.
+ *   Default is `process.env.npm_execpath`.
  * @returns {Promise}
  *   A promise object which becomes fullfilled when all npm-scripts are completed.
  */

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -136,7 +136,7 @@ module.exports = function runTask(task, options) {
         }
 
         if (path.extname(options.npmPath || "a.js") === ".js") {
-            const npmPath = options.npmPath || process.env.NPM_EXECPATH  //eslint-disable-line no-process-env
+            const npmPath = options.npmPath || process.env.npm_execpath  //eslint-disable-line no-process-env
             const execPath = npmPath ? process.execPath : "npm"
             const spawnArgs = [].concat(
                 npmPath ? [npmPath, "run"] : ["run"],


### PR DESCRIPTION
Change `NPM_EXECPATH` -> `npm_execpath`, this variable is case sensitive. This likely works on your windows environment because the env variables are [case insensitive on windows ](https://en.wikipedia.org/wiki/Environment_variable#Windows_2). This is currently breaking on a yarn project (no npm installed) running on a mac.

[Yarn](https://github.com/yarnpkg/yarn/blob/c3191986dd0c75214441b6c9160019014b1fa34d/src/util/execute-lifecycle-script.js#L31) and [NPM](https://github.com/npm/npm/blob/30d75e738b9cb7a6a3f9b50e971adcbe63458ed3/lib/utils/lifecycle.js#L76) use of `npm_execpath` (to see the case sensitivity).