### PR TITLE
ADD --mute/-m flag to mute GROUPS or TASKS

### DIFF
--- a/bin/common/parse-cli-args.js
+++ b/bin/common/parse-cli-args.js
@@ -14,7 +14,7 @@
 const OVERWRITE_OPTION = /^--([^:]+?):([^=]+?)(?:=(.+))?$/
 const CONFIG_OPTION = /^--([^=]+?)(?:=(.+))$/
 const PACKAGE_CONFIG_PATTERN = /^npm_package_config_(.+)$/
-const CONCAT_OPTIONS = /^-[clnprs]+$/
+const CONCAT_OPTIONS = /^-[clmnprs]+$/
 
 /**
  * Overwrites a specified package config.
@@ -182,6 +182,17 @@ function parseCLIArgsCore(set, args) {    // eslint-disable-line complexity
                 addGroup(set.groups, {parallel: true})
                 break
 
+            case "-m":
+            case "--mute":
+                var muteTask = !!set.lastGroup.patterns.length
+                if (muteTask) {
+                  var task = set.lastGroup.patterns.pop()
+                  set.lastGroup.patterns.push([task, '--mute'])
+                } else {
+                  set.lastGroup.mute = true
+                }
+                break
+
             case "--npm-path":
                 set.npmPath = args[++i] || null
                 break
@@ -209,7 +220,8 @@ function parseCLIArgsCore(set, args) {    // eslint-disable-line complexity
                     throw new Error(`Invalid Option: ${arg}`)
                 }
                 else {
-                    set.lastGroup.patterns.push(arg)
+                    var isMute = set.lastGroup.mute
+                    set.lastGroup.patterns.push(isMute ? [arg, '--mute'] : arg)
                 }
 
                 break

--- a/lib/index.js
+++ b/lib/index.js
@@ -253,7 +253,11 @@ module.exports = function npmRunAll(patternOrPatterns, options) {
                 return readPackageJson()
             })
             .then(x => {
-                const tasks = matchTasks(x.taskList, patterns)
+                const opts = patterns.map(x=>{
+                  if (x[1] === '--mute') return { mute: true }
+                })
+                const pats = patterns.map(x=> typeof x === 'string' ? x : x[0])
+                const tasks = matchTasks(x.taskList, pats)
                 const labelWidth = tasks.reduce(maxLength, 0)
 
                 return runTasks(tasks, {
@@ -273,7 +277,7 @@ module.exports = function npmRunAll(patternOrPatterns, options) {
                     race,
                     maxParallel,
                     npmPath,
-                })
+                }, opts)
             })
     }
     catch (err) {

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -49,14 +49,15 @@ function selectColor(taskName) {
  * @param {object} labelState - An label state for the transform stream.
  * @returns {stream.Writable} `source` or the created wrapped stream.
  */
-function wrapLabeling(taskName, source, labelState) {
+function wrapLabeling(taskName, source, labelState, opts) {
     if (source == null || !labelState.enabled) {
         return source
     }
 
     const label = padEnd(taskName, labelState.width)
     const color = source.isTTY ? selectColor(taskName) : (x) => x
-    const prefix = color(`[${label}] `)
+    var isMuted = (opts||{}).mute ? '  MUTED' : ''
+    const prefix = color(`[${label + isMuted}] `)
     const stream = createPrefixTransform(prefix, labelState)
 
     stream.pipe(source)
@@ -115,12 +116,12 @@ function detectStreamKind(stream, std) {
  *   This promise object has an extra method: `abort()`.
  * @private
  */
-module.exports = function runTask(task, options) {
+module.exports = function runTask(task, options, opts) {
     let cp = null
     const promise = new Promise((resolve, reject) => {
         const stdin = options.stdin
-        const stdout = wrapLabeling(task, options.stdout, options.labelState)
-        const stderr = wrapLabeling(task, options.stderr, options.labelState)
+        const stdout = wrapLabeling(task, options.stdout, options.labelState, opts)
+        const stderr = wrapLabeling(task, options.stderr, options.labelState, opts)
         const stdinKind = detectStreamKind(stdin, process.stdin)
         const stdoutKind = detectStreamKind(stdout, process.stdout)
         const stderrKind = detectStreamKind(stderr, process.stderr)
@@ -145,7 +146,7 @@ module.exports = function runTask(task, options) {
             )
 
             // Execute.
-            cp = spawn(execPath, spawnArgs, spawnOptions)
+            cp = spawn(execPath, spawnArgs, spawnOptions, opts)
         }
         else {
             const execPath = options.npmPath
@@ -156,7 +157,7 @@ module.exports = function runTask(task, options) {
             )
 
             // Execute.
-            cp = spawn(execPath, spawnArgs, spawnOptions)
+            cp = spawn(execPath, spawnArgs, spawnOptions, opts)
         }
 
         // Piping stdio.
@@ -187,6 +188,5 @@ module.exports = function runTask(task, options) {
             cp = null
         }
     }
-
     return promise
 }

--- a/lib/run-tasks.js
+++ b/lib/run-tasks.js
@@ -45,7 +45,7 @@ function remove(array, x) {
  * @returns {Promise} A promise object which becomes fullfilled when all npm-scripts are completed.
  * @private
  */
-module.exports = function runTasks(tasks, options) {
+module.exports = function runTasks(tasks, options, opts) {
     return new Promise((resolve, reject) => {
         if (tasks.length === 0) {
             resolve([])
@@ -53,7 +53,9 @@ module.exports = function runTasks(tasks, options) {
         }
 
         const results = tasks.map(task => ({name: task, code: undefined}))
-        const queue = tasks.map((task, index) => ({name: task, index}))
+        const queue = tasks.map((task, index) => ({
+          name: task, index, opts: opts[index]
+        }))
         const promises = []
         let error = null
         let aborted = false
@@ -105,7 +107,7 @@ module.exports = function runTasks(tasks, options) {
                 return
             }
             const task = queue.shift()
-            const promise = runTask(task.name, options)
+            const promise = runTask(task.name, options, task.opts)
 
             promises.push(promise)
             promise.then(

--- a/lib/spawn.js
+++ b/lib/spawn.js
@@ -18,3 +18,12 @@
 module.exports = require(
     process.platform === "win32" ? "./spawn-win32" : "./spawn-posix"
 )
+
+var fn = require(process.platform === "win32" ? "./spawn-win32" : "./spawn-posix")
+module.exports = function spawn (command, args, options, opts) {
+  if (opts && opts.mute) {
+    args = ['--silent'].concat(`${[command].concat(args).join(' ')}`)
+    command = require.resolve('execr').replace('index.js', 'runner.js')
+  }
+  return fn(command, args, options)
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "cross-spawn": "^5.0.1",
+    "execr": "^1.0.1",
     "minimatch": "^3.0.2",
     "ps-tree": "^1.0.1",
     "read-pkg": "^2.0.0",


### PR DESCRIPTION
**This pull request is not mergable yet, but it works.**

1. Probably the way it's implemented is not ok for now.
2. I also did not update any readme's yet.
3. Who knows how the "API" should look like

...but i really would like to have this feature.

# Use Case

Every time i need to run a combination of tasks, like for example:
* a static http server
* a selenium server for testing
* run a test suite
* maybe a live-reloading thing
* ...

I would like to just type `npm start` or `npm test` and everything that needs to start starts.
I would also like to have logging of the important stuff and quit all those processes when i want.

`npm-run-all` does that, but when all those processes log to the terminal, i dont see what i consider important, so i'd like to be able to mute the tasks i dont want to see.


# Example

```json
{
  "scripts": {
    "AAA": "echo AAA",
    "BBB": "echo BBB",
    "YO": "echo YO",
    "A": "echo A",
    "YO": "echo YO",
    "test": "npm-run-all -nsm AAA -pl BBB AAA BBB -mlpr --silent YO -m --silent A B -s --mute AAA -- --asdf 5"
  }
}
```

So `npm test` will mute:
* all tasks of group 1 **['AAA']** because `-nsm` has `-m` after `-s`
* the last task **'BBB'** of group 2 ['BBB', 'AAA', 'BBB'] because of `-mlpr` has `-m` before `-p`
* task **'YO'** of group 3 ['YO', 'A', 'B'] because of `-m` after `YO`
* all tasks of group 4 ['AAA'], because of `--mute` after `-s`


