### PR TITLE
Aggregate output per command

### DIFF
--- a/bin/common/parse-cli-args.js
+++ b/bin/common/parse-cli-args.js
@@ -174,6 +174,10 @@ function parseCLIArgsCore(set, args) {    // eslint-disable-line complexity
                 addGroup(set.groups)
                 break
 
+            case "--aggregateOutput":
+                set.aggregateOutput = true
+                break
+
             case "-p":
             case "--parallel":
                 if (set.singleMode) {

--- a/bin/common/parse-cli-args.js
+++ b/bin/common/parse-cli-args.js
@@ -174,7 +174,7 @@ function parseCLIArgsCore(set, args) {    // eslint-disable-line complexity
                 addGroup(set.groups)
                 break
 
-            case "--aggregateOutput":
+            case "--aggregate-output":
                 set.aggregateOutput = true
                 break
 

--- a/bin/run-p/help.js
+++ b/bin/run-p/help.js
@@ -33,6 +33,8 @@ Options:
                                threw error(s).
     --max-parallel <number>  - Set the maximum number of parallelism. Default is
                                unlimited.
+    --aggregate-output       - Avoid interleaving output by delaying printing of
+                               each command's output until it has finished.
     --npm-path <string>  - - - Set the path to npm. Default is the value of
                                environment variable npm_execpath.
                                If the variable is not defined, then it's "npm."

--- a/bin/run-p/main.js
+++ b/bin/run-p/main.js
@@ -52,6 +52,7 @@ module.exports = function npmRunAll(args, stdout, stderr) {
                 arguments: argv.rest,
                 race: argv.race,
                 npmPath: argv.npmPath,
+                aggregateOutput: argv.aggregateOutput,
             }
         )
 

--- a/docs/run-p.md
+++ b/docs/run-p.md
@@ -37,6 +37,8 @@ Options:
                                threw error(s).
     --max-parallel <number>  - Set the maximum number of parallelism. Default is
                                unlimited.
+    --aggregate-output       - Avoid interleaving output by delaying printing of
+                               each command's output until it has finished.
     --npm-path <string>  - - - Set the path to npm. Default is the value of
                                environment variable npm_execpath.
                                If the variable is not defined, then it's "npm."

--- a/lib/index.js
+++ b/lib/index.js
@@ -223,6 +223,7 @@ module.exports = function npmRunAll(patternOrPatterns, options) {
     const printName = Boolean(options && options.printName)
     const race = Boolean(options && options.race)
     const maxParallel = parallel ? ((options && options.maxParallel) || 0) : 1
+    const aggregateOutput = Boolean(options && options.aggregateOutput)
     const npmPath = options && options.npmPath
     try {
         const patterns = parsePatterns(patternOrPatterns, args)
@@ -273,6 +274,7 @@ module.exports = function npmRunAll(patternOrPatterns, options) {
                     race,
                     maxParallel,
                     npmPath,
+                    aggregateOutput,
                 })
             })
     }

--- a/lib/run-tasks.js
+++ b/lib/run-tasks.js
@@ -10,6 +10,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
+const streams = require("memory-streams")
 const NpmRunAllError = require("./npm-run-all-error")
 const runTask = require("./run-task")
 
@@ -104,8 +105,17 @@ module.exports = function runTasks(tasks, options) {
                 }
                 return
             }
+
+            const originalOutputStream = options.stdout
+            const optionsClone = Object.assign({}, options)
+            const writer = new streams.WritableStream()
+
+            if (options.aggregateOutput) {
+                optionsClone.stdout = writer
+            }
+
             const task = queue.shift()
-            const promise = runTask(task.name, options)
+            const promise = runTask(task.name, optionsClone)
 
             promises.push(promise)
             promise.then(
@@ -113,6 +123,10 @@ module.exports = function runTasks(tasks, options) {
                     remove(promises, promise)
                     if (aborted) {
                         return
+                    }
+
+                    if (options.aggregateOutput) {
+                        originalOutputStream.write(writer.toString())
                     }
 
                     // Save the result.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "cross-spawn": "^5.0.1",
+    "memory-streams": "^0.1.2",
     "minimatch": "^3.0.2",
     "ps-tree": "^1.0.1",
     "read-pkg": "^2.0.0",

--- a/test-workspace/package.json
+++ b/test-workspace/package.json
@@ -36,7 +36,8 @@
     "test-task:dump": "node tasks/dump.js",
     "test-task:nest-append:npm-run-all": "node ../bin/npm-run-all/index.js test-task:append",
     "test-task:nest-append:run-s": "node ../bin/run-s/index.js test-task:append",
-    "test-task:nest-append:run-p": "node ../bin/run-p/index.js test-task:append"
+    "test-task:nest-append:run-p": "node ../bin/run-p/index.js test-task:append",
+    "test-task:delayed": "node tasks/output-with-delay.js"
   },
   "repository": {
     "type": "git",

--- a/test-workspace/tasks/output-with-delay.js
+++ b/test-workspace/tasks/output-with-delay.js
@@ -1,0 +1,7 @@
+"use strict"
+
+const text = process.argv[2]
+const timeout = process.argv[3]
+
+process.stdout.write(`[${text}]`)
+setTimeout(() => process.stdout.write(`__[${text}]\n`), timeout)

--- a/test/aggregate-output.js
+++ b/test/aggregate-output.js
@@ -1,0 +1,90 @@
+
+/**
+ * @author Toru Nagashima
+ * @copyright 2016 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict"
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("power-assert")
+const nodeApi = require("../lib")
+const BufferStream = require("./lib/buffer-stream")
+const util = require("./lib/util")
+const runAll = util.runAll
+const runPar = util.runPar
+const runSeq = util.runSeq
+
+//------------------------------------------------------------------------------
+// Test
+//------------------------------------------------------------------------------
+
+describe.only("[aggregated-output] npm-run-all", () => {
+    before(() => process.chdir("test-workspace"))
+    after(() => process.chdir(".."))
+
+    /**
+     * create expected text
+     * @param {string} term  the term to use when creating a line
+     * @returns {string} the complete line
+     */
+    function createExpectedOutput(term) {
+        return `[${term}]__[${term}]`
+    }
+
+    describe("should not intermingle output of various commands", () => {
+        const EXPECTED_SERIALIZED_TEXT = [
+            createExpectedOutput("first"),
+            createExpectedOutput("second"),
+            `${createExpectedOutput("third")}\n`,
+        ].join("\n")
+
+        const EXPECTED_PARALLELIZED_TEXT = [
+            createExpectedOutput("second"),
+            createExpectedOutput("third"),
+            `${createExpectedOutput("first")}\n`,
+        ].join("\n")
+
+        let stdout = null
+
+        beforeEach(() => {
+            stdout = new BufferStream()
+        })
+
+        it("Node API", () => nodeApi(
+                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200"],
+                    {stdout, silent: true, aggregateOutput: true}
+                )
+                .then(() => {
+                    assert.equal(stdout.value, EXPECTED_SERIALIZED_TEXT)
+                }))
+
+        it("npm-run-all command", () => runAll(
+                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200", "--silent", "--aggregateOutput"],
+                    stdout
+                )
+                .then(() => {
+                    assert.equal(stdout.value, EXPECTED_SERIALIZED_TEXT)
+                }))
+
+        it("run-s command", () => runSeq(
+                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200", "--silent", "--aggregateOutput"],
+                    stdout
+                )
+                .then(() => {
+                    assert.equal(stdout.value, EXPECTED_SERIALIZED_TEXT)
+                }))
+
+        it("run-p command", () => runPar(
+                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200", "--silent", "--aggregateOutput"],
+                    stdout
+                )
+                .then(() => {
+                    assert.equal(stdout.value, EXPECTED_PARALLELIZED_TEXT)
+                }))
+    })
+})
+

--- a/test/aggregate-output.js
+++ b/test/aggregate-output.js
@@ -63,7 +63,7 @@ describe("[aggregated-output] npm-run-all", () => {
                 }))
 
         it("npm-run-all command", () => runAll(
-                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200", "--silent", "--aggregateOutput"],
+                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200", "--silent", "--aggregate-output"],
                     stdout
                 )
                 .then(() => {
@@ -71,7 +71,7 @@ describe("[aggregated-output] npm-run-all", () => {
                 }))
 
         it("run-s command", () => runSeq(
-                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200", "--silent", "--aggregateOutput"],
+                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200", "--silent", "--aggregate-output"],
                     stdout
                 )
                 .then(() => {
@@ -82,7 +82,7 @@ describe("[aggregated-output] npm-run-all", () => {
             "test-task:delayed first 3000",
             "test-task:delayed second 1000",
             "test-task:delayed third 2000",
-            "--silent", "--aggregateOutput"],
+            "--silent", "--aggregate-output"],
                     stdout
                 )
                 .then(() => {

--- a/test/aggregate-output.js
+++ b/test/aggregate-output.js
@@ -22,7 +22,7 @@ const runSeq = util.runSeq
 // Test
 //------------------------------------------------------------------------------
 
-describe.only("[aggregated-output] npm-run-all", () => {
+describe("[aggregated-output] npm-run-all", () => {
     before(() => process.chdir("test-workspace"))
     after(() => process.chdir(".."))
 
@@ -78,8 +78,11 @@ describe.only("[aggregated-output] npm-run-all", () => {
                     assert.equal(stdout.value, EXPECTED_SERIALIZED_TEXT)
                 }))
 
-        it("run-p command", () => runPar(
-                    ["test-task:delayed first 300", "test-task:delayed second 100", "test-task:delayed third 200", "--silent", "--aggregateOutput"],
+        it("run-p command", () => runPar([
+            "test-task:delayed first 300",
+            "test-task:delayed second 100",
+            "test-task:delayed third 200",
+            "--silent", "--aggregateOutput"],
                     stdout
                 )
                 .then(() => {

--- a/test/aggregate-output.js
+++ b/test/aggregate-output.js
@@ -79,9 +79,9 @@ describe("[aggregated-output] npm-run-all", () => {
                 }))
 
         it("run-p command", () => runPar([
-            "test-task:delayed first 300",
-            "test-task:delayed second 100",
-            "test-task:delayed third 200",
+            "test-task:delayed first 3000",
+            "test-task:delayed second 1000",
+            "test-task:delayed third 2000",
             "--silent", "--aggregateOutput"],
                     stdout
                 )


### PR DESCRIPTION
This implements #36 - support for aggregating output from each command. The option `--aggregateOutput` makes all output from each command be output in a single write to stdout. The first command to complete will be the first one to show its output and so on.

The tests I added follow other patterns, but might be simplified IMHO, as I think it doesn't add much to test the output from the serialized commands, as it doesn't make much sense without parallelization. An alternative could be to throw when the option is toggled on a serialized run of commands. 