### PR TITLE
Fix: Use ansi-style directly instead of chalk.styles

### DIFF
--- a/lib/create-header.js
+++ b/lib/create-header.js
@@ -10,7 +10,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const chalk = require("chalk")
+const ansiStyles = require("ansi-styles")
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -38,7 +38,7 @@ module.exports = function createHeader(nameAndArgs, packageInfo, isTTY) {
     const packageVersion = packageInfo.body.version
     const scriptBody = packageInfo.body.scripts[name]
     const packagePath = packageInfo.path
-    const color = isTTY ? chalk.styles.gray : { open: "", close: "" }
+    const color = isTTY ? ansiStyles.gray : { open: "", close: "" }
 
     return `
 ${color.open}> ${packageName}@${packageVersion} ${name} ${packagePath}${color.close}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "codecov": "nyc report -r lcovonly && codecov"
   },
   "dependencies": {
+    "ansi-styles": "^3.2.0",
     "chalk": "^2.1.0",
     "cross-spawn": "^5.1.0",
     "memory-streams": "^0.1.2",


### PR DESCRIPTION
In v4.1.0, An error occurs with `-n` option.
This PR is to fix this.

```
➜  npm test

> app@1.0.0 test /Users/koba04/app
> run-p -n lint flow:check unittest

ERROR: Cannot read property 'gray' of undefined
npm ERR! Test failed.  See above for more details.
```

`chalk` v2 has removed `chalk.styles` API so I use `ansi-styles` instead of this.

* https://github.com/chalk/chalk/releases/tag/v2.0.0

Thanks!