### PR TITLE
Allow built-in install task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 /test-workspace/tasks/lib
 /test-workspace/test.txt
 /test.js
-npm-debug.log
+/*.log

--- a/lib/match-tasks.js
+++ b/lib/match-tasks.js
@@ -18,6 +18,7 @@ const Minimatch = require("minimatch").Minimatch
 
 const COLON_OR_SLASH = /[:/]/g
 const CONVERT_MAP = { ":": "/", "/": ":" }
+const BUILT_IN_TASKS = ["restart", "env", "install"]
 
 /**
  * Swaps ":" and "/", in order to use ":" as the separator in minimatch.
@@ -78,6 +79,18 @@ class TaskSet {
     }
 }
 
+/**
+ * Checks if an array includes an item.
+ *
+ * @param {*[]} array - an array which may or may not include the item.
+ * @param {*} item - an item to check if the array includes it.
+ *
+ * @returns {boolean} whether array includes item
+ */
+function arrayIncludes(array, item) {
+    return array.indexOf(item) > -1
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -111,7 +124,7 @@ module.exports = function matchTasks(taskList, patterns) {
         }
 
         // Built-in tasks should be allowed.
-        if (!found && (filter.task === "restart" || filter.task === "env")) {
+        if (!found && arrayIncludes(BUILT_IN_TASKS, filter.task)) {
             taskSet.add(filter.task + filter.args, filter.task)
             found = true
         }

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -80,6 +80,28 @@ function detectStreamKind(stream, std) {
     )
 }
 
+/**
+ * Create spawnArgs for running a task.
+ *
+ * @param {string|undefined} npmPath any available npmPath
+ * @param {string} task the run-script to execute, or "install"
+ * @param {object} prefixOptions options for spawn
+ * @returns {Array.<*>} args for spawn
+ */
+function createSpawnArgs(npmPath, task, prefixOptions) {
+    if (task === "install") {
+        return [].concat(
+            npmPath ? [npmPath, "install"] : ["install"],
+            prefixOptions
+        )
+    }
+
+    return [].concat(
+        npmPath ? [npmPath, "run"] : ["run"],
+        prefixOptions,
+        parseArgs(task)
+    )
+}
 //------------------------------------------------------------------------------
 // Interface
 //------------------------------------------------------------------------------
@@ -138,22 +160,14 @@ module.exports = function runTask(task, options) {
         if (path.extname(options.npmPath || "a.js") === ".js") {
             const npmPath = options.npmPath || process.env.npm_execpath  //eslint-disable-line no-process-env
             const execPath = npmPath ? process.execPath : "npm"
-            const spawnArgs = [].concat(
-                npmPath ? [npmPath, "run"] : ["run"],
-                options.prefixOptions,
-                parseArgs(task)
-            )
+            const spawnArgs = createSpawnArgs(npmPath, task, options.prefixOptions)
 
             // Execute.
             cp = spawn(execPath, spawnArgs, spawnOptions)
         }
         else {
             const execPath = options.npmPath
-            const spawnArgs = [].concat(
-                ["run"],
-                options.prefixOptions,
-                parseArgs(task)
-            )
+            const spawnArgs = createSpawnArgs(undefined, task, options.prefixOptions)
 
             // Execute.
             cp = spawn(execPath, spawnArgs, spawnOptions)

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "node": ">= 4"
   },
   "scripts": {
-    "_mocha": "mocha \"test/*.js\" --compilers js:babel-register --timeout 60000",
+    "_mocha": "mocha \"test/*.js\" --require babel-register --timeout 60000",
     "clean": "rimraf .nyc_output coverage jsdoc \"test-workspace/{build,test.txt}\"",
     "docs": "jsdoc -c jsdoc.json",
     "lint": "eslint bin lib scripts test \"test-workspace/tasks/*.js\"",
@@ -48,7 +48,7 @@
     "eslint": "^4.5.0",
     "eslint-config-mysticatea": "^12.0.0",
     "jsdoc": "^3.5.4",
-    "mocha": "^3.5.0",
+    "mocha": "^4.0.1",
     "nyc": "^11.1.0",
     "power-assert": "^1.4.4",
     "rimraf": "^2.6.1"

--- a/test/common.js
+++ b/test/common.js
@@ -251,6 +251,13 @@ describe("[common]", () => {
         it("run-p command", () => runPar(["env"]))
     })
 
+    describe("should be able to use `install` built-in task:", () => {
+        it("Node API", () => nodeApi("install"))
+        it("npm-run-all command", () => runAll(["install"]))
+        it("run-s command", () => runSeq(["install"]))
+        it("run-p command", () => runPar(["install"]))
+    })
+
     if (process.platform === "win32") {
         describe("issue14", () => {
             it("Node API", () => nodeApi("test-task:issue14:win32"))


### PR DESCRIPTION
Wow! What a nice, well-structured repo and tool you have here!

I want to be able to have a run-script `"install-sub-dependencies": "cd sub/ && run-s install"`, which does `npm install` or `yarn install` to install the dependencies in the `sub/` project, depending on how the main script was called.

This PR enables the `install` task, which is run without `"run"` before it.