### PR TITLE
fix: colorize tasks names sequentially instead of by hash

### DIFF
--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -24,6 +24,9 @@ const spawn = require("./spawn")
 
 const colors = [chalk.cyan, chalk.green, chalk.magenta, chalk.yellow, chalk.red]
 
+let colorIndex = 0
+const taskNamesToColors = {}
+
 /**
  * Select a color from given task name.
  *
@@ -31,14 +34,13 @@ const colors = [chalk.cyan, chalk.green, chalk.magenta, chalk.yellow, chalk.red]
  * @returns {function} A colorize function that provided by `chalk`
  */
 function selectColor(taskName) {
-    let hash = 0
-
-    for (const c of taskName) {
-        hash = ((hash << 5) - hash) + c
-        hash |= 0
+    let color = taskNamesToColors[taskName]
+    if (!color) {
+        color = colors[colorIndex]
+        colorIndex = (colorIndex + 1) % colors.length
+        taskNamesToColors[taskName] = color
     }
-
-    return colors[Math.abs(hash) % colors.length]
+    return color
 }
 
 /**

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -25,7 +25,7 @@ const spawn = require("./spawn")
 const colors = [chalk.cyan, chalk.green, chalk.magenta, chalk.yellow, chalk.red]
 
 let colorIndex = 0
-const taskNamesToColors = {}
+const taskNamesToColors = new Map()
 
 /**
  * Select a color from given task name.
@@ -34,11 +34,11 @@ const taskNamesToColors = {}
  * @returns {function} A colorize function that provided by `chalk`
  */
 function selectColor(taskName) {
-    let color = taskNamesToColors[taskName]
+    let color = taskNamesToColors.get(taskName)
     if (!color) {
         color = colors[colorIndex]
         colorIndex = (colorIndex + 1) % colors.length
-        taskNamesToColors[taskName] = color
+        taskNamesToColors.set(taskName, color)
     }
     return color
 }


### PR DESCRIPTION
The current strategy to colorize task labels relies on hashing the task name, but there's no guarantee that this won't cause tasks to be colored identically. This PR instead simply keeps an index into the array of available colors and increments it whenever it sees a new task name. Tasks are thus guaranteed to use all the available colors before repeating.

Before fix, running two parallel tasks whose names hash to the same color index:
![screenshot from 2017-11-24 20 40 26](https://user-images.githubusercontent.com/567041/33226430-3302d764-d15b-11e7-90fd-eeb09c2e59a4.png)

After fix:
![screenshot from 2017-11-24 20 53 44](https://user-images.githubusercontent.com/567041/33226431-3468fa3e-d15b-11e7-8545-ec16c4d79905.png)
