### PR TITLE
Special chars

### DIFF
--- a/lib/match-tasks.js
+++ b/lib/match-tasks.js
@@ -43,7 +43,7 @@ function createFilter(pattern) {
     const spacePos = trimmed.indexOf(" ")
     const task = spacePos < 0 ? trimmed : trimmed.slice(0, spacePos)
     const args = spacePos < 0 ? "" : trimmed.slice(spacePos)
-    const matcher = new Minimatch(swapColonAndSlash(task))
+    const matcher = new Minimatch(swapColonAndSlash(task), { nonegate: true })
     const match = matcher.match.bind(matcher)
 
     return { match, task, args }

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -82,6 +82,22 @@ function detectStreamKind(stream, std) {
     )
 }
 
+/**
+ * Ensure the output of shell-quote's `parse()` is acceptable input to npm-cli.
+ *
+ * The `parse()` method of shell-quote sometimes returns special objects in its
+ * output array, e.g. if it thinks some elements should be globbed. But npm-cli
+ * only accepts strings and will throw an error otherwise.
+ *
+ * See https://github.com/substack/node-shell-quote#parsecmd-env
+ *
+ * @param {object|string} arg - Item in the output of shell-quote's `parse()`.
+ * @returns {string} A valid argument for npm-cli.
+ */
+function cleanTaskArg(arg) {
+    return arg.pattern || arg.op || arg
+}
+
 //------------------------------------------------------------------------------
 // Interface
 //------------------------------------------------------------------------------
@@ -153,7 +169,7 @@ module.exports = function runTask(task, options) {
         else if (options.prefixOptions.indexOf("--silent") !== -1) {
             spawnArgs.push("--silent")
         }
-        Array.prototype.push.apply(spawnArgs, parseArgs(task))
+        Array.prototype.push.apply(spawnArgs, parseArgs(task).map(cleanTaskArg))
 
         cp = spawn(execPath, spawnArgs, spawnOptions)
 

--- a/test-workspace/package.json
+++ b/test-workspace/package.json
@@ -38,7 +38,9 @@
     "test-task:nest-append:run-s": "node ../bin/run-s/index.js test-task:append",
     "test-task:nest-append:run-p": "node ../bin/run-p/index.js test-task:append",
     "test-task:delayed": "node tasks/output-with-delay.js",
-    "test-task:yarn": "node ../bin/npm-run-all/index.js test-task:append:{a,b} --npm-path yarn"
+    "test-task:yarn": "node ../bin/npm-run-all/index.js test-task:append:{a,b} --npm-path yarn",
+    "!test": "node tasks/append1.js X",
+    "?test": "node tasks/append1.js Q"
   },
   "repository": {
     "type": "git",

--- a/test/pattern.js
+++ b/test/pattern.js
@@ -188,4 +188,26 @@ describe("[pattern] it should run matched tasks if glob like patterns are given.
             }
         })
     })
+
+    describe("\"!test\" \"?test\" to \"!test\", \"?test\"", () => {
+        it("Node API", async () => {
+            await nodeApi(["!test", "?test"])
+            assert(result().trim() === "XQ")
+        })
+
+        it("npm-run-all command", async () => {
+            await runAll(["!test", "?test"])
+            assert(result().trim() === "XQ")
+        })
+
+        it("run-s command", async () => {
+            await runSeq(["!test", "?test"])
+            assert(result().trim() === "XQ")
+        })
+
+        it("run-p command", async () => {
+            await runPar(["!test", "?test"])
+            assert(result().trim() === "XQ" || result().trim() === "QX")
+        })
+    })
 })

--- a/test/pattern.js
+++ b/test/pattern.js
@@ -143,4 +143,49 @@ describe("[pattern] it should run matched tasks if glob like patterns are given.
             }
         })
     })
+
+    describe("\"!test-task:**\" should not match to anything", () => {
+        it("Node API", async () => {
+            try {
+                await nodeApi("!test-task:**")
+                assert(false, "should not match")
+            }
+            catch (err) {
+                assert((/not found/i).test(err.message))
+            }
+        })
+
+        it("npm-run-all command", async () => {
+            const stderr = new BufferStream()
+            try {
+                await runAll(["!test-task:**"], null, stderr)
+                assert(false, "should not match")
+            }
+            catch (_err) {
+                assert((/not found/i).test(stderr.value))
+            }
+        })
+
+        it("run-s command", async () => {
+            const stderr = new BufferStream()
+            try {
+                await runSeq(["!test-task:**"], null, stderr)
+                assert(false, "should not match")
+            }
+            catch (_err) {
+                assert((/not found/i).test(stderr.value))
+            }
+        })
+
+        it("run-p command", async () => {
+            const stderr = new BufferStream()
+            try {
+                await runPar(["!test-task:**"], null, stderr)
+                assert(false, "should not match")
+            }
+            catch (_err) {
+                assert((/not found/i).test(stderr.value))
+            }
+        })
+    })
 })


### PR DESCRIPTION
Hi,

First of all: thanks for this great module!

I ran into some issues with tasks whose names begin with special characters like `'!'` or `'?'`. These work fine when I invoke `npm run` but fail if I run them with npm-run-all.

Example:
```json
{
  "scripts": {
    "?clean": "echo Clean the project",
    "!clean": "rimraf dist/**/*",
    "clean": "run-s -ls ?clean !clean"
  }
}
```

```sh
$ npm run ?clean  # works
$ npm run clean  # fails
```

I've tracked this down to two distinct issues:
- minimatch treats a leading exclamation mark `'!'` as a negation -- I think this is almost never what we want for matching tasks (it would mean "run everything except ..."). On that assumption I've added an option to the minimatch constructor telling it to treat exclamation marks the same as other chars.
- shell-quote's `parse()` method sometimes returns objects instead of strings, for example when it thinks something is a glob. But npm-cli doesn't understand anything except strings, and throws errors otherwise. Since we've already handled any globbing by the time we get to shell-quote `parse()`, I've added a simple mapper function which cleans up the parse output to ensure we pass valid input to npm-cli.
- There are tests in this PR for both changes.

I would really appreciate if you might consider merging these changes and include them in a new release. Of course, if you have suggestions for improvements please let me know and I'll amend the PR.

PS -- I've had to restart the Travis builds a couple of times, due to an error which is unrelated to my changes... I wasn't able to figure it out quickly but you might want to have a look at why the following test is (sometimes) failing:
https://github.com/mysticatea/npm-run-all/blob/master/test/parallel.js#L240
