### PR TITLE
Swap chalk for turbocolor.

### DIFF
--- a/lib/create-header.js
+++ b/lib/create-header.js
@@ -10,7 +10,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const ansiStyles = require("ansi-styles")
+const color = require("turbocolor")
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -23,10 +23,9 @@ const ansiStyles = require("ansi-styles")
  * @param {object} packageInfo - A package.json's information.
  * @param {object} packageInfo.body - A package.json's JSON object.
  * @param {string} packageInfo.path - A package.json's file path.
- * @param {boolean} isTTY - The flag to color the header.
  * @returns {string} The header of a given task.
  */
-module.exports = function createHeader(nameAndArgs, packageInfo, isTTY) {
+module.exports = function createHeader(nameAndArgs, packageInfo) {
     if (!packageInfo) {
         return `\n> ${nameAndArgs}\n\n`
     }
@@ -38,11 +37,10 @@ module.exports = function createHeader(nameAndArgs, packageInfo, isTTY) {
     const packageVersion = packageInfo.body.version
     const scriptBody = packageInfo.body.scripts[name]
     const packagePath = packageInfo.path
-    const color = isTTY ? ansiStyles.gray : { open: "", close: "" }
 
-    return `
-${color.open}> ${packageName}@${packageVersion} ${name} ${packagePath}${color.close}
-${color.open}> ${scriptBody} ${args}${color.close}
+    return color.gray(`
+> ${packageName}@${packageVersion} ${name} ${packagePath}
+> ${scriptBody} ${args}
 
-`
+`)
 }

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -11,7 +11,7 @@
 //------------------------------------------------------------------------------
 
 const path = require("path")
-const chalk = require("chalk")
+const turbo = require("turbocolor")
 const parseArgs = require("shell-quote").parse
 const padEnd = require("string.prototype.padend")
 const createHeader = require("./create-header")
@@ -22,7 +22,7 @@ const spawn = require("./spawn")
 // Helpers
 //------------------------------------------------------------------------------
 
-const colors = [chalk.cyan, chalk.green, chalk.magenta, chalk.yellow, chalk.red]
+const colors = [turbo.cyan, turbo.green, turbo.magenta, turbo.yellow, turbo.red]
 
 let colorIndex = 0
 const taskNamesToColors = new Map()
@@ -31,7 +31,7 @@ const taskNamesToColors = new Map()
  * Select a color from given task name.
  *
  * @param {string} taskName - The task name.
- * @returns {function} A colorize function that provided by `chalk`
+ * @returns {function} A colorize function that provided by `turbocolor`
  */
 function selectColor(taskName) {
     let color = taskNamesToColors.get(taskName)
@@ -148,8 +148,7 @@ module.exports = function runTask(task, options) {
         if (options.printName && stdout != null) {
             stdout.write(createHeader(
                 task,
-                options.packageInfo,
-                options.stdout.isTTY
+                options.packageInfo
             ))
         }
 

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "codecov": "nyc report -r lcovonly && codecov"
   },
   "dependencies": {
-    "ansi-styles": "^3.2.0",
-    "chalk": "^2.1.0",
+    "turbocolor": "^2.0.1",
     "cross-spawn": "^6.0.4",
     "memorystream": "^0.3.1",
     "minimatch": "^3.0.4",

--- a/test/print-name.js
+++ b/test/print-name.js
@@ -38,51 +38,50 @@ describe("[print-name] npm-run-all", () => {
         it("Node API", async () => {
             const stdout = new BufferStream()
             await nodeApi("test-task:echo abc", { stdout, silent: true, printName: true })
-            const header = createHeader("test-task:echo abc", packageInfo, false)
+            const header = createHeader("test-task:echo abc", packageInfo)
             assert.equal(stdout.value.slice(0, header.length), header)
         })
 
         it("npm-run-all command (--print-name)", async () => {
             const stdout = new BufferStream()
             await runAll(["test-task:echo abc", "--silent", "--print-name"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
+            const header = createHeader("test-task:echo abc", packageInfo)
             assert.equal(stdout.value.slice(0, header.length), header)
         })
 
         it("run-s command (--print-name)", async () => {
             const stdout = new BufferStream()
             await runSeq(["test-task:echo abc", "--silent", "--print-name"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
+            const header = createHeader("test-task:echo abc", packageInfo)
             assert.equal(stdout.value.slice(0, header.length), header)
         })
 
         it("run-p command (--print-name)", async () => {
             const stdout = new BufferStream()
             await runPar(["test-task:echo abc", "--silent", "--print-name"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
+            const header = createHeader("test-task:echo abc", packageInfo)
             assert.equal(stdout.value.slice(0, header.length), header)
         })
 
         it("npm-run-all command (-n)", async () => {
             const stdout = new BufferStream()
             await runAll(["test-task:echo abc", "--silent", "-n"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
+            const header = createHeader("test-task:echo abc", packageInfo)
             assert.equal(stdout.value.slice(0, header.length), header)
         })
 
         it("run-s command (-n)", async () => {
             const stdout = new BufferStream()
             await runSeq(["test-task:echo abc", "--silent", "-n"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
+            const header = createHeader("test-task:echo abc", packageInfo)
             assert.equal(stdout.value.slice(0, header.length), header)
         })
 
         it("run-p command (-n)", async () => {
             const stdout = new BufferStream()
             await runPar(["test-task:echo abc", "--silent", "-n"], stdout)
-            const header = createHeader("test-task:echo abc", packageInfo, false)
+            const header = createHeader("test-task:echo abc", packageInfo)
             assert.equal(stdout.value.slice(0, header.length), header)
         })
     })
 })
-


### PR DESCRIPTION
Hello @mysticatea! 👋 

This PR basically swaps chalk for [Turbocolor](https://github.com/jorgebucaran/turbocolor).

It will give you a perf boost as turbocolor loads **_>20x_** faster and applies styles **_>18x_** faster than chalk for the same API (see [benchmarks](https://github.com/jorgebucaran/turbocolor/tree/master/bench#benchmarks)). In addition, turbocolor will *not* stop coloring when !isTTY (there's an config option instead), so I was able to remove an extra dependency (ansi-styles). It supports Node.js >=v4.

<pre>
# Load Time
chalk: 15.190ms
<b>turbocolor: 0.777ms</b>

# All Colors
chalk × 8,729 ops/sec
<b>turbocolor × 158,383 ops/sec</b>

# Chained Colors
chalk × 1,838 ops/sec
<b>turbocolor × 39,830 ops/sec</b>

# Nested Colors
chalk × 4,049 ops/sec
<b>turbocolor × 59,833 ops/sec</b>
</pre>

Let me know if this is acceptable to you. Cheers!