### PR TITLE
Add npm-run as alias for npm-run-all

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "bin": {
     "run-p": "bin/run-p/index.js",
     "run-s": "bin/run-s/index.js",
-    "npm-run-all": "bin/npm-run-all/index.js"
+    "npm-run-all": "bin/npm-run-all/index.js",
+    "npm-run": "bin/npm-run-all/index.js"
   },
   "main": "lib/index.js",
   "files": [


### PR DESCRIPTION
Editing tasks from node'ran to npm-run-all'ran tasks it is much more convenient to do if it only demands to add a `-` compared to also adding the last `-all` part. It also looks better (in my opinion). 

One argument against this is that it becomes harder for people to recognise that this command is not the native command and how to find the documentation. Having the choice does not limit the ones who want to keep the original notation and as the package-unrelated command names `run-s` and `run-p` are already supported, we are not introducing added complexity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mysticatea/npm-run-all/156)
<!-- Reviewable:end -->
