### PR TITLE
feat: support exotic manifests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ sudo: false
 
 language: node_js
 node_js:
-  - "4.0.0"
-  - "4"
-  - "6"
   - "8"
   - "10"
-  - "11"
+  - "12"
 
 script:
   - npm test

--- a/lib/read-package-json.js
+++ b/lib/read-package-json.js
@@ -10,8 +10,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const joinPath = require("path").join
-const readPkg = require("read-pkg")
+const pathResolve = require("path").resolve
+const readManifest = require("@pnpm/read-importer-manifest").default
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -23,9 +23,11 @@ const readPkg = require("read-pkg")
  * @returns {object} package.json's information.
  */
 module.exports = function readPackageJson() {
-    const path = joinPath(process.cwd(), "package.json")
-    return readPkg(path).then(body => ({
-        taskList: Object.keys(body.scripts || {}),
-        packageInfo: { path, body },
+    return readManifest(process.cwd()).then(readResult => ({
+        taskList: Object.keys(readResult.manifest.scripts || {}),
+        packageInfo: {
+            body: readResult.manifest,
+            path: pathResolve(readResult.fileName),
+        },
     }))
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs"
   ],
   "engines": {
-    "node": ">= 4"
+    "node": ">= 8.15"
   },
   "scripts": {
     "_mocha": "mocha \"test/*.js\" --timeout 120000",
@@ -29,13 +29,13 @@
     "codecov": "nyc report -r lcovonly && codecov"
   },
   "dependencies": {
+    "@pnpm/read-importer-manifest": "^1.0.0",
     "ansi-styles": "^3.2.1",
     "chalk": "^2.4.1",
     "cross-spawn": "^6.0.5",
     "memorystream": "^0.3.1",
     "minimatch": "^3.0.4",
     "pidtree": "^0.3.0",
-    "read-pkg": "^3.0.0",
     "shell-quote": "^1.6.1",
     "string.prototype.padend": "^3.0.0"
   },


### PR DESCRIPTION
pnpm v3.3.0 will support `package.json5` and `package.yaml` (pnpm v3.3.0-0 is already out with the support).

This implementation involves a pnpm library that only supports Node.js>=8.15, so I understand if it will be rejected. Also, a test is required. Just want to know if you'd be fine supporting it. If no, I will publish a fork for pnpm usage.