### PR TITLE
Handle Signals

### DIFF
--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -189,9 +189,9 @@ module.exports = function runTask(task, options) {
             cp = null
             reject(err)
         })
-        cp.on("close", (code) => {
+        cp.on("close", (code, signal) => {
             cp = null
-            resolve({ task, code })
+            resolve({ task, code, signal })
         })
     })
 

--- a/lib/run-tasks.js
+++ b/lib/run-tasks.js
@@ -11,7 +11,6 @@
 //------------------------------------------------------------------------------
 
 const MemoryStream = require("memorystream")
-const convert = require("signal-numbers").convert
 const NpmRunAllError = require("./npm-run-all-error")
 const runTask = require("./run-task")
 
@@ -31,6 +30,39 @@ function remove(array, x) {
     if (index !== -1) {
         array.splice(index, 1)
     }
+}
+
+const signals = {
+    SIGABRT: 6,
+    SIGALRM: 14,
+    SIGBUS: 10,
+    SIGCHLD: 20,
+    SIGCONT: 19,
+    SIGFPE: 8,
+    SIGHUP: 1,
+    SIGILL: 4,
+    SIGINT: 2,
+    SIGKILL: 9,
+    SIGPIPE: 13,
+    SIGQUIT: 3,
+    SIGSEGV: 11,
+    SIGSTOP: 17,
+    SIGTERM: 15,
+    SIGTRAP: 5,
+    SIGTSTP: 18,
+    SIGTTIN: 21,
+    SIGTTOU: 22,
+    SIGUSR1: 30,
+    SIGUSR2: 31,
+}
+
+/**
+ * Converts a signal name to a number.
+ * @param {string} signal - the signal name to convert into a number
+ * @returns {number} - the return code for the signal
+ */
+function convert(signal) {
+    return signals[signal] || 0
 }
 
 //------------------------------------------------------------------------------

--- a/lib/run-tasks.js
+++ b/lib/run-tasks.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 const MemoryStream = require("memorystream")
+const convert = require("signal-numbers").convert
 const NpmRunAllError = require("./npm-run-all-error")
 const runTask = require("./run-task")
 
@@ -131,6 +132,15 @@ module.exports = function runTasks(tasks, options) {
 
                     if (options.aggregateOutput) {
                         originalOutputStream.write(writer.toString())
+                    }
+
+                    // Check if the task failed as a result of a signal, and
+                    // amend the exit code as a result.
+                    if (result.code === null && result.signal !== null) {
+                        // An exit caused by a signal must return a status code
+                        // of 128 plus the value of the signal code.
+                        // Ref: https://nodejs.org/api/process.html#process_exit_codes
+                        result.code = 128 + convert(result.signal)
                     }
 
                     // Save the result.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "pidtree": "^0.3.0",
     "read-pkg": "^3.0.0",
     "shell-quote": "^1.6.1",
-    "signal-numbers": "^0.2.2",
     "string.prototype.padend": "^3.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "pidtree": "^0.3.0",
     "read-pkg": "^3.0.0",
     "shell-quote": "^1.6.1",
+    "signal-numbers": "^0.2.2",
     "string.prototype.padend": "^3.0.0"
   },
   "devDependencies": {

--- a/test-workspace/package.json
+++ b/test-workspace/package.json
@@ -26,6 +26,7 @@
     "test-task:append:b": "node tasks/append2.js b",
     "test-task:append1": "node tasks/append1.js",
     "test-task:append2": "node tasks/append2.js",
+    "test-task:abort": "node tasks/abort.js",
     "test-task:error": "node tasks/error.js",
     "test-task:stdout": "node tasks/stdout.js > test.txt",
     "test-task:stderr": "node tasks/stderr.js 2> test.txt",

--- a/test-workspace/tasks/abort.js
+++ b/test-workspace/tasks/abort.js
@@ -1,0 +1,5 @@
+"use strict"
+
+setTimeout(() => {
+    process.abort()
+}, 500)

--- a/test/fail.js
+++ b/test/fail.js
@@ -101,4 +101,16 @@ describe("[fail] it should fail", () => {
         it("run-s command", () => shouldFail(runSeq(["test-task:error"])))
         it("run-p command", () => shouldFail(runPar(["test-task:error"])))
     })
+
+    describe("if tasks exited via a signal:", () => {
+        it("Node API", () => shouldFail(nodeApi("test-task:abort")))
+        it("npm-run-all command", () => shouldFail(runAll(["test-task:abort"])))
+        it("run-s command", () => shouldFail(runSeq(["test-task:abort"])))
+        it("run-p command", () => shouldFail(runPar(["test-task:abort"])))
+        it("tests", () => nodeApi("test-task:abort").then(() =>
+            assert(false, "should fail")
+        ).catch(err => {
+            assert(err.code === 134, "should have correct exit code")
+        }))
+    })
 })

--- a/test/fail.js
+++ b/test/fail.js
@@ -107,10 +107,14 @@ describe("[fail] it should fail", () => {
         it("npm-run-all command", () => shouldFail(runAll(["test-task:abort"])))
         it("run-s command", () => shouldFail(runSeq(["test-task:abort"])))
         it("run-p command", () => shouldFail(runPar(["test-task:abort"])))
-        it("tests", () => nodeApi("test-task:abort").then(() =>
+        it("with correct exit code", () => nodeApi("test-task:abort").then(() =>
             assert(false, "should fail")
         ).catch(err => {
-            assert(err.code === 134, "should have correct exit code")
+            // In NodeJS versions > 6, the child process correctly sends back
+            // the signal + code of null. In NodeJS versions <= 6, the child
+            // process does not set the signal, and sets the code to 1.
+            const code = Number(process.version.match(/^v(\d+)/)[1]) > 6 ? 134 : 1
+            assert(err.code === code, "should have correct exit code")
         }))
     })
 })


### PR DESCRIPTION
We discovered an issue where `npm-run-all` swallows errors caused by the v8 runtime, specifically, the `SIGABRT` signal sent when the node process experiences a `JavaScript heap out of memory` error.

From the documentation available https://nodejs.org/api/child_process.html, it indicates that when the process closes, if the code provided is `null`, then the subprocess terminated due to a signal.

The standard behaviour that NodeJS implements when running code that causes these errors directly is to return an exit code of 128 plus the value of the signal code.

This PR does one thing, checks to see if the `code` is null, and a signal was provided, convert the signal to it's number version, and then mutates the return code used by the rest of `npm-run-all` by adding 128 to the signal value.