### PR TITLE
Placeholder to unfold single task into multiple tasks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,8 @@ const runTasks = require("./run-tasks")
 // Helpers
 //------------------------------------------------------------------------------
 
-const ARGS_PATTERN = /\{(!)?([*@]|\d+)([^}]+)?}/g
+const ARGS_PATTERN = /\{(!)?([*@%]|\d+)([^}]+)?}/g
+const ARGS_UNPACK_PATTERN = /\{(!)?(%)([^}]+)?}/g
 
 /**
  * Converts a given value to an array.
@@ -44,7 +45,22 @@ function toArray(x) {
 function applyArguments(patterns, args) {
     const defaults = Object.create(null)
 
-    return patterns.map(pattern => pattern.replace(ARGS_PATTERN, (whole, indirectionMark, id, options) => {
+    const unfoldedPatterns = patterns
+        .map(pattern => {
+            const match = ARGS_UNPACK_PATTERN.exec(pattern);
+            if (match && match[2] === "%") {
+                const result = [];
+                for (var index in args) {
+                    const argPosition = parseInt(index, 10) + 1;
+                    result.push(pattern.replace(ARGS_UNPACK_PATTERN, () => '{' + argPosition + '}'));
+                }
+                return result;
+            }
+            return pattern;
+        })
+        .flat();
+
+    return unfoldedPatterns.map(pattern => pattern.replace(ARGS_PATTERN, (whole, indirectionMark, id, options) => {
         if (indirectionMark != null) {
             throw Error(`Invalid Placeholder: ${whole}`)
         }
@@ -227,6 +243,7 @@ module.exports = function npmRunAll(patternOrPatterns, options) { //eslint-disab
     const npmPath = options && options.npmPath
     try {
         const patterns = parsePatterns(patternOrPatterns, args)
+        console.log('😜 patterns', patterns, patternOrPatterns);
         if (patterns.length === 0) {
             return Promise.resolve(null)
         }


### PR DESCRIPTION
### What is it?

This adds a new placeholder, `{%}`, which unfolds into multiple tasks – one for each input argument. The unfolded tasks gets assigned `{1}`, `{2}` etc instead of `{%}`.

### Purpose

Be able to in parallell process a single npm task X times with a different argument each time.

### Example

```json
{
  "minimize-image": "some-cli-command",
  "build:image": "run-p 'minimize-image -- {%}' -- ./foo.png ./bar.png"
}
```

Same as:
```bash
run-p 'minimize-image -- ./foo.png' 'minimize-image -- ./bar.png'
```

### Example using shell globbing

```json
{
  "minimize-image": "some-cli-command",
  "build:image": "run-p 'minimize-image -- {%}' -- ./images/*.png"
}
```