### PR TITLE
remove dependency on chalk

### DIFF
--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -11,7 +11,7 @@
 //------------------------------------------------------------------------------
 
 const path = require("path")
-const chalk = require("chalk")
+const ansiStyles = require("ansi-styles")
 const parseArgs = require("shell-quote").parse
 const padEnd = require("string.prototype.padend")
 const createHeader = require("./create-header")
@@ -22,7 +22,7 @@ const spawn = require("./spawn")
 // Helpers
 //------------------------------------------------------------------------------
 
-const colors = [chalk.cyan, chalk.green, chalk.magenta, chalk.yellow, chalk.red]
+const colors = ["cyan", "green", "magenta", "yellow", "red"]
 
 let colorIndex = 0
 const taskNamesToColors = new Map()
@@ -57,8 +57,8 @@ function wrapLabeling(taskName, source, labelState) {
     }
 
     const label = padEnd(taskName, labelState.width)
-    const color = source.isTTY ? selectColor(taskName) : (x) => x
-    const prefix = color(`[${label}] `)
+    const color = source.isTTY ? ansiStyles[selectColor(taskName)] : { open: "", close: "" }
+    const prefix = `${color.open}[${label}]${color.close} `
     const stream = createPrefixTransform(prefix, labelState)
 
     stream.pipe(source)

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "dependencies": {
     "ansi-styles": "^3.2.1",
-    "chalk": "^2.4.1",
     "cross-spawn": "^6.0.5",
     "memorystream": "^0.3.1",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
This package already depends on `ansi-styles`, which is what `chalk` uses under the hood, so I utilized it for getting ANSI escape codes for colors in the TTY.