### PR TITLE
Update read-pkg dependency to version 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "memorystream": "^0.3.1",
     "minimatch": "^3.0.4",
     "pidtree": "^0.3.0",
-    "read-pkg": "^3.0.0",
+    "read-pkg": "^6.0.0",
     "shell-quote": "^1.6.1",
     "string.prototype.padend": "^3.0.0"
   },


### PR DESCRIPTION
Previous versions of read-pkg have a dependency with a vulnerability.