### PR TITLE
Add `succeeded` to `--race` description to clarify what `--race` does

### DIFF
--- a/bin/npm-run-all/help.js
+++ b/bin/npm-run-all/help.js
@@ -49,7 +49,7 @@ Options:
                                e.g. 'npm-run-all -p foo bar' is similar to
                                     'npm run foo & npm run bar'.
     -r, --race   - - - - - - - Set the flag to kill all tasks when a task
-                               finished with zero. This option is valid only
+                               finished with zero (succeeded). This option is valid only
                                with 'parallel' option.
     -s, --sequential <tasks> - Run a group of tasks sequentially.
         --serial <tasks>       e.g. 'npm-run-all -s foo bar' is similar to

--- a/bin/run-p/help.js
+++ b/bin/run-p/help.js
@@ -46,7 +46,7 @@ Options:
     -n, --print-name   - - - - Set the flag to print the task name before
                                running each task.
     -r, --race   - - - - - - - Set the flag to kill all tasks when a task
-                               finished with zero.
+                               finished with zero (succeeded).
     -s, --silent   - - - - - - Set 'silent' to the log level of npm.
 
     Shorthand aliases can be combined.

--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -35,7 +35,7 @@ Options:
                                e.g. 'npm-run-all -p foo bar' is similar to
                                     'npm run foo & npm run bar'.
     -r, --race   - - - - - - - Set the flag to kill all tasks when a task
-                               finished with zero. This option is valid only
+                               finished with zero (succeeded). This option is valid only
                                with 'parallel' option.
     -s, --sequential <tasks> - Run a group of tasks sequentially.
         --serial <tasks>       e.g. 'npm-run-all -s foo bar' is similar to

--- a/docs/run-p.md
+++ b/docs/run-p.md
@@ -35,7 +35,7 @@ Options:
     -n, --print-name   - - - - Set the flag to print the task name before
                                running each task.
     -r, --race   - - - - - - - Set the flag to kill all tasks when a task
-                               finished with zero.
+                               finished with zero (succeeded).
     -s, --silent   - - - - - - Set 'silent' to the log level of npm.
 
     Shorthand aliases can be combined.


### PR DESCRIPTION
Fixes #227

I didn't realize until 5min in that `0` meant one of the commands had succeeded, so I'd like to suggest clarifying that.

Not a total fan of the way I've formatted it, so feel free to make changes