### PR TITLE
remove padend dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ sudo: false
 
 language: node_js
 node_js:
-  - "4.0.0"
-  - "4"
-  - "6"
-  - "8"
-  - "10"
-  - "11"
+  - "14"
+  - "16"
+  - "18"
 
 script:
   - npm test

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -13,7 +13,6 @@
 const path = require("path")
 const chalk = require("chalk")
 const parseArgs = require("shell-quote").parse
-const padEnd = require("string.prototype.padend")
 const createHeader = require("./create-header")
 const createPrefixTransform = require("./create-prefix-transform-stream")
 const spawn = require("./spawn")
@@ -56,7 +55,7 @@ function wrapLabeling(taskName, source, labelState) {
         return source
     }
 
-    const label = padEnd(taskName, labelState.width)
+    const label = taskName.padEnd(labelState.width)
     const color = source.isTTY ? selectColor(taskName) : (x) => x
     const prefix = color(`[${label}] `)
     const stream = createPrefixTransform(prefix, labelState)

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "minimatch": "^3.0.4",
     "pidtree": "^0.3.0",
     "read-pkg": "^3.0.0",
-    "shell-quote": "^1.6.1",
-    "string.prototype.padend": "^3.0.0"
+    "shell-quote": "^1.6.1"
   },
   "devDependencies": {
     "@types/node": "^4.9.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs"
   ],
   "engines": {
-    "node": ">= 4"
+    "node": ">= 12"
   },
   "scripts": {
     "_mocha": "mocha \"test/*.js\" --timeout 120000",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "docs"
   ],
   "engines": {
-    "node": ">= 12"
+    "node": ">= 14"
   },
   "scripts": {
     "_mocha": "mocha \"test/*.js\" --timeout 120000",


### PR DESCRIPTION
This replaces the use of the string.prototype.padend dependency with the normal String.padEnd function, removing the need for 3.3Mb of dependencies.

This PR fixes https://github.com/mysticatea/npm-run-all/issues/241