### PR TITLE
Ensure `npm run` is being called instead of `npx run`

### DIFF
--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -157,7 +157,7 @@ module.exports = function runTask(task, options) {
         const npmPath = options.npmPath || process.env.npm_execpath //eslint-disable-line no-process-env
         const npmPathIsJs = typeof npmPath === "string" && /\.m?js/.test(path.extname(npmPath))
         const execPath = (npmPathIsJs ? process.execPath : npmPath || "npm")
-        const isYarn = path.basename(npmPath || "npm").startsWith("yarn")
+        const isYarn = process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn") //eslint-disable-line no-process-env
         const spawnArgs = ["run"]
 
         if (npmPathIsJs) {

--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -154,7 +154,7 @@ module.exports = function runTask(task, options) {
         }
 
         // Execute.
-        const npmPath = options.npmPath || process.env.npm_execpath //eslint-disable-line no-process-env
+        const npmPath = options.npmPath || process.env.NPM_CLI_JS || process.env.npm_execpath //eslint-disable-line no-process-env
         const npmPathIsJs = typeof npmPath === "string" && /\.m?js/.test(path.extname(npmPath))
         const execPath = (npmPathIsJs ? process.execPath : npmPath || "npm")
         const isYarn = process.env.npm_config_user_agent && process.env.npm_config_user_agent.startsWith("yarn") //eslint-disable-line no-process-env


### PR DESCRIPTION
## Problem:
If you run `npm-run-all` using `npx` (EX: `npx npm-run-all clean build:dev test`), it will prompt you to install [`runjs`](https://github.com/DTrejo/run.js/) if it is not already installed.

![Screenshot_2022-10-28_13-41-05](https://user-images.githubusercontent.com/106682128/198722592-044c761c-af5c-45a2-876a-6eb62d411a69.png)

Then, it will throw an error that looks something like this:
![image](https://user-images.githubusercontent.com/106682128/198680427-92e0a838-4ed5-40a6-a430-a146e0797a71.png)

This is because running `npx npm-run-all` causes `process.env.npm_execpath` to point to `npx` instead of `npm`.

![npm_cli_is_npx](https://user-images.githubusercontent.com/106682128/198657617-6c0a6e8b-14a4-401a-ae5d-fef49e808e77.png)

The underlying command ends up something like `npx run clean` which will attempt to run [`runjs`](https://github.com/DTrejo/run.js/blob/master/run.js) instead of running the npm scripts, and of course, `clean` isn't a javascript file or anything that `runjs` can do anything with, so that is why it throws. 

For reference, this is what it looks like when I intentionally run `runjs` in place of `npm run`.
![image](https://user-images.githubusercontent.com/106682128/198680619-897b913e-9976-4653-8b8d-2b176945dc57.png)
If you look here at [run.js](https://github.com/DTrejo/run.js/blob/master/run.js#L60), you can see the code that is being unintentionally ran by `npm-run-all`.

I am pretty sure this problem is related to #196. The error looks to be *exactly* the same, and on my machine, `yarn` aliases to `npx yarn` which would cause `yarn` to throw an error where `npm` would work fine.
_yarn:_
![image](https://user-images.githubusercontent.com/106682128/198666566-34c00c96-2a8e-46bd-a668-7f8d35360bc6.png)
_npm:_
![image](https://user-images.githubusercontent.com/106682128/198666727-a57a62f9-3214-40c8-b8ae-725805241756.png)

## Testing:

I went ahead and ran the [automated tests in GH actions](https://github.com/MarmadileManteater/npm-run-all/actions/runs/3346155479/jobs/5542604887#step:5:1), and all the of the current tests look like they pass with these changes. It might make sense to introduce a test for running `npm-run-all` using `npx`, and maybe, even one for running `yarn` with `npx`.

[UPDATE]: not sure why AppVeyor tests failed (I mean, the tests didn't even run, they just crapped out before they started). The error does not seem to be related to my changes at all, so idk 🤷‍♀️  I'm looking into it, but if someone knows, I would love clarification.
```
Cannot find module 'C:\projects\npm-run-all\node'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:636:15)
    at Function.Module._load (internal/modules/cjs/loader.js:562:25)
    at Function.Module.runMain (internal/modules/cjs/loader.js:831:12)
    at startup (internal/bootstrap/node.js:283:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:623:3)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! npm-run-all@4.1.5 _mocha: `mocha "test/*.js" --timeo
```
[2ND UPDATE]: It seems that the same error is happening in other PRs which don't even touch the code:

EX: #216 => https://ci.appveyor.com/project/mysticatea/npm-run-all/builds/41262284
This PR only touches a markdown file, so it looks like the App Veyor PR test doesn't work anymore which is not super suprising since the last commit was 3 years ago.

## Additional Information

I also modified how yarn is detected because I modified `npmPath` (which was how yarn was being detected previously). Before, `isYarn` was false when `npx` was used in conjunction with `yarn`. With these changes, it should actually detect yarn even if you run `yarn` using `npx`. (EX `npx yarn dev`)

_before:_
![before](https://user-images.githubusercontent.com/106682128/198673909-2446dc4d-ac98-4de6-8870-774d5cc6334b.png)
_after:_
![image](https://user-images.githubusercontent.com/106682128/198677177-feca9629-4f7d-49cf-ab90-2f750f59c51f.png)
