### PR TITLE
Update shell-quote to 1.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "minimatch": "^3.0.4",
     "pidtree": "^0.3.0",
     "read-pkg": "^3.0.0",
-    "shell-quote": "^1.6.1",
+    "shell-quote": "^1.7.3",
     "string.prototype.padend": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The shell-quote package before 1.7.3 for Node.js allows command injection.