### PR TITLE
docs: recommend quoting for portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A CLI tool to run multiple npm-scripts in parallel or sequential.
 
 - **Simplify.** The official `npm run-script` command cannot run multiple scripts, so if we want to run multiple scripts, it's redundant a bit. Let's shorten it by glob-like patterns.<br>
   Before: `npm run clean && npm run build:css && npm run build:js && npm run build:html`<br>
-  After: `npm-run-all clean build:*`
+  After: `npm-run-all clean 'build:*'`
 - **Cross platform.** We sometimes use `&` to run multiple command in parallel, but `cmd.exe` (`npm run-script` uses it by default) does not support the `&`. Half of Node.js users are using it on Windows, so the use of `&` might block contributions. `npm-run-all --parallel` works well on Windows as well.
 
 ## 💿 Installation

--- a/bin/npm-run-all/help.js
+++ b/bin/npm-run-all/help.js
@@ -58,8 +58,8 @@ Options:
     --silent   - - - - - - - - Set 'silent' to the log level of npm.
 
 Examples:
-    $ npm-run-all --serial clean lint build:**
-    $ npm-run-all --parallel watch:**
+    $ npm-run-all --serial clean lint 'build:**'
+    $ npm-run-all --parallel 'watch:**'
     $ npm-run-all clean lint --parallel "build:** -- --watch"
     $ npm-run-all -l -p start-server start-browser start-electron
 

--- a/bin/run-p/help.js
+++ b/bin/run-p/help.js
@@ -53,7 +53,7 @@ Options:
     For example, '-clns' equals to '-c -l -n -s'.
 
 Examples:
-    $ run-p watch:**
+    $ run-p 'watch:**'
     $ run-p --print-label "build:** -- --watch"
     $ run-p -sl "build:** -- --watch"
     $ run-p start-server start-browser start-electron

--- a/bin/run-s/help.js
+++ b/bin/run-s/help.js
@@ -47,10 +47,10 @@ Options:
     For example, '-clns' equals to '-c -l -n -s'.
 
 Examples:
-    $ run-s build:**
-    $ run-s lint clean build:**
-    $ run-s --silent --print-name lint clean build:**
-    $ run-s -sn lint clean build:**
+    $ run-s 'build:**'
+    $ run-s lint clean 'build:**'
+    $ run-s --silent --print-name lint clean 'build:**'
+    $ run-s -sn lint clean 'build:**'
 
 See Also:
     https://github.com/mysticatea/npm-run-all#readme

--- a/docs/npm-run-all.md
+++ b/docs/npm-run-all.md
@@ -44,8 +44,8 @@ Options:
     --silent   - - - - - - - - Set 'silent' to the log level of npm.
 
 Examples:
-    $ npm-run-all --serial clean lint build:**
-    $ npm-run-all --parallel watch:**
+    $ npm-run-all --serial clean lint 'build:**'
+    $ npm-run-all --parallel 'watch:**'
     $ npm-run-all clean lint --parallel "build:** -- --watch"
     $ npm-run-all -l -p start-server start-browser start-electron
 ```
@@ -121,14 +121,14 @@ We can use [glob]-like patterns to specify npm-scripts.
 The difference is one -- the separator is `:` instead of `/`.
 
 ```
-$ npm-run-all --parallel watch:*
+$ npm-run-all --parallel 'watch:*'
 ```
 
 In this case, runs sub scripts of `watch`. For example: `watch:html`, `watch:js`.
 But, doesn't run sub-sub scripts. For example: `watch:js:index`.
 
 ```
-$ npm-run-all --parallel watch:**
+$ npm-run-all --parallel 'watch:**'
 ```
 
 If we use a globstar `**`, runs both sub scripts and sub-sub scripts.

--- a/docs/run-p.md
+++ b/docs/run-p.md
@@ -42,7 +42,7 @@ Options:
     For example, '-clns' equals to '-c -l -n -s'.
 
 Examples:
-    $ run-p watch:**
+    $ run-p 'watch:**'
     $ run-p --print-label "build:** -- --watch"
     $ run-p -l "build:** -- --watch"
     $ run-p start-server start-browser start-electron
@@ -85,14 +85,14 @@ We can use [glob]-like patterns to specify npm-scripts.
 The difference is one -- the separator is `:` instead of `/`.
 
 ```
-$ run-p watch:*
+$ run-p 'watch:*'
 ```
 
 In this case, runs sub scripts of `watch`. For example: `watch:html`, `watch:js`.
 But, doesn't run sub-sub scripts. For example: `watch:js:index`.
 
 ```
-$ run-p watch:**
+$ run-p 'watch:**'
 ```
 
 If we use a globstar `**`, runs both sub scripts and sub-sub scripts.

--- a/docs/run-s.md
+++ b/docs/run-s.md
@@ -36,10 +36,10 @@ Options:
     For example, '-clns' equals to '-c -l -n -s'.
 
 Examples:
-    $ run-s build:**
-    $ run-s lint clean build:**
-    $ run-s --silent --print-name lint clean build:**
-    $ run-s -sn lint clean build:**
+    $ run-s 'build:**'
+    $ run-s lint clean 'build:**'
+    $ run-s --silent --print-name lint clean 'build:**'
+    $ run-s -sn lint clean 'build:**'
 ```
 
 ### npm-scripts
@@ -76,14 +76,14 @@ We can use [glob]-like patterns to specify npm-scripts.
 The difference is one -- the separator is `:` instead of `/`.
 
 ```
-$ run-s build:*
+$ run-s 'build:*'
 ```
 
 In this case, runs sub scripts of `build`. For example: `build:html`, `build:js`.
 But, doesn't run sub-sub scripts. For example: `build:js:index`.
 
 ```
-$ run-s build:**
+$ run-s 'build:**'
 ```
 
 If we use a globstar `**`, runs both sub scripts and sub-sub scripts.


### PR DESCRIPTION
The current recommendation relies on the user's shell's glob handling behaviour. It happens to work because generally `something:*` does not match any files, and so with sh's default behaviour it passes `something:*` as-is as an arg. This breaks down in some other shells though, for example, with zsh:

<img src="https://github.com/mysticatea/npm-run-all/assets/1609021/a571030c-0818-4ede-9919-946cbf1c6634" width="250">

...or with yarn, as referenced in the issues that will be closed by this PR.

This change recommends quoting the globs with single quotes, which will avoid the glob expansion (which requires traversing the file system) and will also be more portable to work in more cases.

Closes https://github.com/mysticatea/npm-run-all/issues/200
Closes https://github.com/mysticatea/npm-run-all/issues/196