### PR TITLE
Increase task label color palette

### DIFF
--- a/lib/run-task.js
+++ b/lib/run-task.js
@@ -22,7 +22,7 @@ const spawn = require("./spawn")
 // Helpers
 //------------------------------------------------------------------------------
 
-const colors = [chalk.cyan, chalk.green, chalk.magenta, chalk.yellow, chalk.red]
+const colors = [chalk.cyan, chalk.green, chalk.magenta, chalk.yellow, chalk.red, chalk.blue, chalk.white, chalk.gray]
 
 let colorIndex = 0
 const taskNamesToColors = new Map()


### PR DESCRIPTION
## Summary

- Expanded the rotating task label colors from 5 to 8 in `lib/run-task.js`
- Reduces repeated colors when running many tasks with `--print-label` in parallel mode

Fixes #85

## Test plan

- [ ] Run multiple tasks (more than 5) in parallel with `--print-label` flag and verify that color repetition is reduced
- [ ] Verify existing tests still pass (`npm test`)